### PR TITLE
S3Hook class is no longer accepting s3_conn_id parameter and it uses aws_conn_id instead

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,14 +1,20 @@
 from airflow.plugins_manager import AirflowPlugin
 from google_analytics_plugin.hooks.google_analytics_hook import GoogleAnalyticsHook
-from google_analytics_plugin.operators.google_analytics_reporting_to_s3_operator import GoogleAnalyticsReportingToS3Operator
-from google_analytics_plugin.operators.google_analytics_account_summaries_to_s3_operator import GoogleAnalyticsAccountSummariesToS3Operator
+from google_analytics_plugin.operators.google_analytics_reporting_to_s3_operator import (
+    GoogleAnalyticsReportingToS3Operator,
+)
+from google_analytics_plugin.operators.google_analytics_account_summaries_to_s3_operator import (
+    GoogleAnalyticsAccountSummariesToS3Operator,
+)
 
 
 class GoogleAnalyticsPlugin(AirflowPlugin):
     name = "google_analytics_plugin"
     hooks = [GoogleAnalyticsHook]
-    operators = [GoogleAnalyticsReportingToS3Operator,
-                 GoogleAnalyticsAccountSummariesToS3Operator]
+    operators = [
+        GoogleAnalyticsReportingToS3Operator,
+        GoogleAnalyticsAccountSummariesToS3Operator,
+    ]
     executors = []
     macros = []
     admin_views = []

--- a/operators/google_analytics_account_summaries_to_s3_operator.py
+++ b/operators/google_analytics_account_summaries_to_s3_operator.py
@@ -9,7 +9,7 @@ from google_analytics_plugin.hooks.google_analytics_hook import GoogleAnalyticsH
 
 
 class GoogleAnalyticsAccountSummariesToS3Operator(BaseOperator):
-    template_fields = ("s3_key",)
+    template_fields = "s3_key"
 
     def __init__(
         self,

--- a/operators/google_analytics_account_summaries_to_s3_operator.py
+++ b/operators/google_analytics_account_summaries_to_s3_operator.py
@@ -9,21 +9,23 @@ from google_analytics_plugin.hooks.google_analytics_hook import GoogleAnalyticsH
 
 
 class GoogleAnalyticsAccountSummariesToS3Operator(BaseOperator):
-    template_fields = ('s3_key',)
+    template_fields = ("s3_key",)
 
-    def __init__(self,
-                 google_analytics_conn_id,
-                 s3_conn_id,
-                 s3_bucket,
-                 s3_key,
-                 brand,
-                 space,
-                 *args,
-                 **kwargs):
+    def __init__(
+        self,
+        google_analytics_conn_id,
+        aws_conn_id,
+        s3_bucket,
+        s3_key,
+        brand,
+        space,
+        *args,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
 
         self.google_analytics_conn_id = google_analytics_conn_id
-        self.s3_conn_id = s3_conn_id
+        self.aws_conn_id = aws_conn_id
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
         self.brand = brand
@@ -31,32 +33,32 @@ class GoogleAnalyticsAccountSummariesToS3Operator(BaseOperator):
 
     def execute(self, context):
         ga_conn = GoogleAnalyticsHook(self.google_analytics_conn_id)
-        s3_conn = S3Hook(self.s3_conn_id)
+        s3_conn = S3Hook(self.aws_conn_id)
 
         account_summaries = ga_conn.get_account_summaries()
 
-        file_name = '/tmp/{key}.jsonl'.format(key=self.s3_key)
-        with open(file_name, 'w') as ga_file:
+        file_name = "/tmp/{key}.jsonl".format(key=self.s3_key)
+        with open(file_name, "w") as ga_file:
             data = []
-            for item in account_summaries.get('items', []):
+            for item in account_summaries.get("items", []):
                 root_data_obj = {
-                    'account_id': item['id'],
-                    'brand': self.brand,
-                    'space': self.space
+                    "account_id": item["id"],
+                    "brand": self.brand,
+                    "space": self.space,
                 }
 
-                for web_property in item.get('webProperties', []):
+                for web_property in item.get("webProperties", []):
                     data_obj = {}
                     data_obj.update(root_data_obj)
 
-                    data_obj['property_id'] = web_property['id']
+                    data_obj["property_id"] = web_property["id"]
 
-                    for profile in web_property.get('profiles', []):
-                        data_obj['profile_id'] = profile['id']
-                        data_obj['profile_name'] = profile['name']
+                    for profile in web_property.get("profiles", []):
+                        data_obj["profile_id"] = profile["id"]
+                        data_obj["profile_name"] = profile["name"]
                         data.append(data_obj)
 
-            json_data = '\n'.join([json.dumps(d) for d in data])
+            json_data = "\n".join([json.dumps(d) for d in data])
             ga_file.write(json_data)
 
         s3_conn.load_file(file_name, self.s3_key, self.s3_bucket, True)


### PR DESCRIPTION
S3Hook class is [no longer accepting s3_conn_id parameter](https://issues.apache.org/jira/browse/AIRFLOW-1795) and it uses aws_conn_id instead