### PR TITLE
Corrected invalid format for requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-api-core=1.2.1
+google-api-core==1.2.1
 google-api-python-client==1.7.3
 oauth2client==4.1.2


### PR DESCRIPTION
```
Invalid requirement: 'google-api-core=1.2.1'
= is not a valid operator. Did you mean == ?
```